### PR TITLE
MinLOS refocusing

### DIFF
--- a/include/openfv/refocusing.h
+++ b/include/openfv/refocusing.h
@@ -242,6 +242,7 @@ class saRefocus {
     vector<int> shifts_;
     int mult_;
     double mult_exp_;
+    int minlos_;
     double warp_factor_;
     int active_frame_;
     int start_frame_;

--- a/include/openfv/typedefs.h
+++ b/include/openfv/typedefs.h
@@ -43,7 +43,8 @@ struct refocus_settings {
     int mult; // 1 for Multiplicative
     //! Multiplicative exponent
     double mult_exp;
-
+    //! Flag to use minLOS (minimum line of sight) reconstruction
+    int minlos; // 1 for minimum line of sight
     //! Flag to use a GPU or not
     int use_gpu; // 1 for GPU
     //! Use Homography Fit (HF) method or not

--- a/src/modules/parse_settings.cpp
+++ b/src/modules/parse_settings.cpp
@@ -15,6 +15,7 @@ void parse_refocus_settings(string filename, refocus_settings &settings, bool h)
         ("use_gpu", po::value<int>()->default_value(0), "ON to use GPU")
         ("mult", po::value<int>()->default_value(0), "ON to use multiplicative method")
         ("mult_exp", po::value<double>()->default_value(.25), "Multiplicative method exponent")
+        ("minlos", po::value<int>()->default_value(0), "ON to use minimum line of sight method")
         ("hf_method", po::value<int>()->default_value(0), "ON to use HF method")
         ("mtiff", po::value<int>()->default_value(0), "ON if data is in multipage tiff files")
         ("mp4", po::value<int>()->default_value(0), "ON if data is in mp4 files")
@@ -52,6 +53,7 @@ void parse_refocus_settings(string filename, refocus_settings &settings, bool h)
     settings.mp4 = vm["mp4"].as<int>();
     settings.mult = vm["mult"].as<int>();
     settings.mult_exp = vm["mult_exp"].as<double>();
+    settings.minlos = vm["minlos"].as<int>();
     settings.resize_images = vm["resize_images"].as<int>();
     settings.rf = vm["rf"].as<double>();
     settings.kalibr = vm["kalibr"].as<int>();


### PR DESCRIPTION
Adding minimum line of sight (minLOS) refocusing to the following refocus modes:
GPU
CPU
GPU refractive
CPU - HF refractive

This method can be used by adding
minlos = 1
to the config file. Otherwise, this variable defaults to 0.

Also adding multiplicative refocusing to CPU - HF refractive

Tested on both GPU and CPU refractive (I don't have any pinhole data to do the other tests).